### PR TITLE
static RavenClient and empty message in CaptureException

### DIFF
--- a/src/app/SharpRaven.Log4Net/SentryAppender.cs
+++ b/src/app/SharpRaven.Log4Net/SentryAppender.cs
@@ -20,7 +20,7 @@ namespace SharpRaven.Log4Net
 
     public class SentryAppender : AppenderSkeleton
     {
-        private static RavenClient ravenClient;
+        private RavenClient ravenClient;
         public string DSN { get; set; }
         public string Logger { get; set; }
         private readonly IList<SentryTag> tagLayouts = new List<SentryTag>();

--- a/src/app/SharpRaven.Log4Net/SentryAppender.cs
+++ b/src/app/SharpRaven.Log4Net/SentryAppender.cs
@@ -62,16 +62,15 @@ namespace SharpRaven.Log4Net
             var tags = tagLayouts.ToDictionary(t => t.Name, t => (t.Layout.Format(loggingEvent) ?? "").ToString());
 
             var exception = loggingEvent.ExceptionObject ?? loggingEvent.MessageObject as Exception;
+            var message = loggingEvent.RenderedMessage;
             var level = Translate(loggingEvent.Level);
 
             if (exception != null)
             {
-                ravenClient.CaptureException(exception, null, level, tags: tags, extra: extra);
+                ravenClient.CaptureException(exception, message, level, tags: tags, extra: extra);
             }
             else
             {
-                var message = loggingEvent.RenderedMessage;
-
                 if (message != null)
                 {
                     ravenClient.CaptureMessage(message, level, tags, extra);


### PR DESCRIPTION
Hope commit comments are self-descriptive.

First one addresses empty message when logging exception - however Sentry allows to specify one simultaneously with exception.

Secondly, sharing a RavenClient client via static reference ends up in only one instance with only one logger name being created. So even if there are several appenders with different logger names writing into single Sentry app they appear with the same logger name in Sentry interface.